### PR TITLE
Remove MonadFix constraint from ArrowLoop instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ type System m = Auto m Double Double
 -- Here, we just lay out the "concepts"/time-varying values in our system as a
 -- recursive/cyclic graph of dependencies.  It's a feedback system, after all.
 --
-pid :: MonadFix m => (Double, Double, Double) -> System m -> System m
+pid :: Monad m => (Double, Double, Double) -> System m -> System m
 pid (kp, ki, kd) blackbox = proc target -> do       -- proc syntax; see tutorial
     rec --  err :: Double
         --  the difference of the response from the target


### PR DESCRIPTION
@mstksg I am not really sure about this change, maybe `MonadFix` brings something to the table which I'm not realising. Anyway, here I go.

This change removes the `MonadFix m` constraint on `ArrowLoop (Auto m)`, thus avoiding the propagation of the `MonadFix` constraint to all other `Auto`s whenever you use `proc` notation's `rec` or`Control.Arrow.loop` on one of them. 

Monads “out there in the wild” are often missing their `MonadFix` instances, and others such as as `ContT` [can't get one due to the way they are definied](https://stackoverflow.com/questions/25827227/why-cant-there-be-an-instance-of-monadfix-for-the-continuation-monad), so this change will prevent the introduction of orphan instances or `newtype` wrappers just to use `Auto`s recursively.

I haven't really thought this through extensively, I don't fully understand the implications of this change, but I wanted to share it with you in case you want to consider that at some point.
