### PR TITLE
Documentation fixes in Control.Auto.Interval

### DIFF
--- a/src/Control/Auto/Serialize.hs
+++ b/src/Control/Auto/Serialize.hs
@@ -71,7 +71,6 @@ import Control.Auto.Blip.Internal
 import Control.Monad.IO.Class
 import Control.Monad
 import Control.Exception
-import Control.Applicative
 import System.IO.Error
 import Control.Auto.Core
 import qualified Data.ByteString as B


### PR DESCRIPTION
Mostly off-by-one errors from 'count'... I assume at one point in time it began counting from 1 :P
