### PR TITLE
Compiling on Debian GHC 7.6

### DIFF
--- a/auto.cabal
+++ b/auto.cabal
@@ -90,8 +90,8 @@ library
                      , base-orphans >= 0.3.1
                      , bytestring   >= 0.10.4.0
                      , cereal       >= 0.4.1.1
-                     , containers   >= 0.5.5.1
-                     , deepseq      >= 1.3.0.2
+                     , containers   >= 0.5
+                     , deepseq      >= 1.3.0
                      , profunctors  >= 4.3
                      , random       >= 1.1
                      , semigroups   >= 0.16


### PR DESCRIPTION
I managed to get the library to compile on GHC 7.6 by relaxing the constraints on containers and deepseq.

With Debian I'm stuck using containers 0.5.0.0 and deepseq 1.3.0.1.

If there is anything else I should do, let me know.
